### PR TITLE
Instance not yet initialised

### DIFF
--- a/lib/src/gesture_navigation/gesture_route_transition_mixin.dart
+++ b/lib/src/gesture_navigation/gesture_route_transition_mixin.dart
@@ -11,10 +11,12 @@ mixin GestureRouteTransitionMixin<T> on ModalRoute<T> {
 
   GestureHandler get gestureHandler => gestureDelegate.gestureHandler;
 
-  GestureHandler? get barrierGestureHandler => gestureDelegate.barrierGestureHandler;
+  GestureHandler? get barrierGestureHandler =>
+      gestureDelegate.barrierGestureHandler;
 
   @override
-  AnimationController createAnimationController() => gestureDelegate.createAnimationController();
+  AnimationController createAnimationController() =>
+      gestureDelegate.createAnimationController();
 
   @override
   void install() {
@@ -35,14 +37,16 @@ mixin GestureRouteTransitionMixin<T> on ModalRoute<T> {
   }
 
   @override
-  Widget buildTransitions(
-      BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
-    final transitionChild = buildPageTransitions(context, animation, secondaryAnimation, child);
-    return buildGestureListener(context, animation, secondaryAnimation, transitionChild);
+  Widget buildTransitions(BuildContext context, Animation<double> animation,
+      Animation<double> secondaryAnimation, Widget child) {
+    final transitionChild =
+        buildPageTransitions(context, animation, secondaryAnimation, child);
+    return buildGestureListener(
+        context, animation, secondaryAnimation, transitionChild);
   }
 
-  Widget buildGestureListener(
-      BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
+  Widget buildGestureListener(BuildContext context, Animation<double> animation,
+      Animation<double> secondaryAnimation, Widget child) {
     return GestureListener(
       handler: gestureDelegate.gestureHandler,
       behavior: gestureBehavior,
@@ -51,8 +55,8 @@ mixin GestureRouteTransitionMixin<T> on ModalRoute<T> {
     );
   }
 
-  Widget buildPageTransitions(
-      BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child);
+  Widget buildPageTransitions(BuildContext context, Animation<double> animation,
+      Animation<double> secondaryAnimation, Widget child);
 
   @override
   void changedInternalState() {
@@ -71,7 +75,7 @@ mixin GestureRouteTransitionMixin<T> on ModalRoute<T> {
 
   Widget buildGestureModalBarrier(BuildContext context) {
     final gestureHandler = barrierGestureHandler;
-    Widget barrier = buildModalBarrier(context, barrierDismissible && gestureHandler == null);
+    Widget barrier = buildModalBarrier();
     if (gestureHandler != null) {
       barrier = Stack(
         children: [
@@ -88,57 +92,59 @@ mixin GestureRouteTransitionMixin<T> on ModalRoute<T> {
     return barrier;
   }
 
-  Widget buildModalBarrier(BuildContext context, bool barrierDismissible) {
-    Widget barrier;
-    if (barrierColor != null && barrierColor!.alpha != 0 && !offstage) {
-      // changedInternalState is called if barrierColor or offstage updates
-      assert(barrierColor != barrierColor!.withOpacity(0.0));
-      final Animation<Color?> color = animation!.drive(
-        ColorTween(
-          begin: barrierColor!.withOpacity(0.0),
-          end: barrierColor, // changedInternalState is called if barrierColor updates
-        ).chain(CurveTween(curve: barrierCurve)), // changedInternalState is called if barrierCurve updates
-      );
-      barrier = AnimatedModalBarrier(
-        color: color,
-        dismissible: barrierDismissible, // changedInternalState is called if barrierDismissible updates
-        semanticsLabel: barrierLabel, // changedInternalState is called if barrierLabel updates
-        barrierSemanticsDismissible: semanticsDismissible,
-      );
-    } else {
-      barrier = ModalBarrier(
-        dismissible: barrierDismissible, // changedInternalState is called if barrierDismissible updates
-        semanticsLabel: barrierLabel, // changedInternalState is called if barrierLabel updates
-        barrierSemanticsDismissible: semanticsDismissible,
-      );
-    }
-    if (filter != null) {
-      barrier = BackdropFilter(
-        filter: filter!,
-        child: barrier,
-      );
-    }
-    barrier = IgnorePointer(
-      ignoring: animation!.status ==
-              AnimationStatus.reverse || // changedInternalState is called when animation.status updates
-          animation!.status == AnimationStatus.dismissed, // dismissed is possible when doing a manual pop gesture
-      child: barrier,
-    );
-    if (semanticsDismissible && this.barrierDismissible) {
-      // To be sorted after the _modalScope.
-      barrier = Semantics(
-        sortKey: const OrdinalSortKey(1.0),
-        child: barrier,
-      );
-    }
-    return barrier;
-  }
+  // Widget buildModalBarrier(BuildContext context, bool barrierDismissible) {
+  //   Widget barrier;
+  //   if (barrierColor != null && barrierColor!.alpha != 0 && !offstage) {
+  //     // changedInternalState is called if barrierColor or offstage updates
+  //     assert(barrierColor != barrierColor!.withOpacity(0.0));
+  //     final Animation<Color?> color = animation!.drive(
+  //       ColorTween(
+  //         begin: barrierColor!.withOpacity(0.0),
+  //         end: barrierColor, // changedInternalState is called if barrierColor updates
+  //       ).chain(CurveTween(curve: barrierCurve)), // changedInternalState is called if barrierCurve updates
+  //     );
+  //     barrier = AnimatedModalBarrier(
+  //       color: color,
+  //       dismissible: barrierDismissible, // changedInternalState is called if barrierDismissible updates
+  //       semanticsLabel: barrierLabel, // changedInternalState is called if barrierLabel updates
+  //       barrierSemanticsDismissible: semanticsDismissible,
+  //     );
+  //   } else {
+  //     barrier = ModalBarrier(
+  //       dismissible: barrierDismissible, // changedInternalState is called if barrierDismissible updates
+  //       semanticsLabel: barrierLabel, // changedInternalState is called if barrierLabel updates
+  //       barrierSemanticsDismissible: semanticsDismissible,
+  //     );
+  //   }
+  //   if (filter != null) {
+  //     barrier = BackdropFilter(
+  //       filter: filter!,
+  //       child: barrier,
+  //     );
+  //   }
+  //   barrier = IgnorePointer(
+  //     ignoring: animation!.status ==
+  //             AnimationStatus.reverse || // changedInternalState is called when animation.status updates
+  //         animation!.status == AnimationStatus.dismissed, // dismissed is possible when doing a manual pop gesture
+  //     child: barrier,
+  //   );
+  //   if (semanticsDismissible && this.barrierDismissible) {
+  //     // To be sorted after the _modalScope.
+  //     barrier = Semantics(
+  //       sortKey: const OrdinalSortKey(1.0),
+  //       child: barrier,
+  //     );
+  //   }
+  //   return barrier;
+  // }
 
   @override
   Iterable<OverlayEntry> createOverlayEntries() {
-    final modalOverlays = List<OverlayEntry>.from(super.createOverlayEntries(), growable: false);
+    final modalOverlays =
+        List<OverlayEntry>.from(super.createOverlayEntries(), growable: false);
     if (barrierGestureHandler != null) {
-      _modalBarrier = OverlayEntry(builder: (context) => buildGestureModalBarrier(context));
+      _modalBarrier =
+          OverlayEntry(builder: (context) => buildGestureModalBarrier(context));
       modalOverlays[0] = _modalBarrier!;
     }
     return modalOverlays;

--- a/lib/src/gesture_navigation/navigator_gesture_recognizer.dart
+++ b/lib/src/gesture_navigation/navigator_gesture_recognizer.dart
@@ -5,7 +5,9 @@ import '../gestures_binding.dart';
 
 mixin NavigatorGesturesPreventingCancelingMixin on GestureRecognizer {
   static NavigatorGesturesBinding? getGestureBinding() {
-    if (GestureBinding.instance is NavigatorGesturesBinding) return GestureBinding.instance as NavigatorGesturesBinding;
+    if (GestureBinding.instance is NavigatorGesturesBinding) {
+      return GestureBinding.instance as NavigatorGesturesBinding;
+    }
     return null;
   }
 
@@ -33,14 +35,29 @@ mixin NavigatorGesturesOneSequenceMixin on OneSequenceGestureRecognizer
   }
 }
 
-class RouteHorizontalDragGestureRecognizer extends HorizontalDragGestureRecognizer
-    with NavigatorGesturesPreventingCancelingMixin, NavigatorGesturesOneSequenceMixin {
-  RouteHorizontalDragGestureRecognizer({Object? debugOwner, PointerDeviceKind? kind /*, Set<PointerDeviceKind>? supportedDevices */})
-      : super(debugOwner: debugOwner, kind: kind/*, supportedDevices: supportedDevices */);
+class RouteHorizontalDragGestureRecognizer
+    extends HorizontalDragGestureRecognizer
+    with
+        NavigatorGesturesPreventingCancelingMixin,
+        NavigatorGesturesOneSequenceMixin {
+  RouteHorizontalDragGestureRecognizer(
+      {Object? debugOwner,
+      PointerDeviceKind? kind /*, Set<PointerDeviceKind>? supportedDevices */
+      })
+      : super(
+          debugOwner: debugOwner, /*, supportedDevices: supportedDevices */
+        );
 }
 
 class RouteVerticalDragGestureRecognizer extends VerticalDragGestureRecognizer
-    with NavigatorGesturesPreventingCancelingMixin, NavigatorGesturesOneSequenceMixin {
-  RouteVerticalDragGestureRecognizer({Object? debugOwner, PointerDeviceKind? kind /*, Set<PointerDeviceKind>? supportedDevices */})
-      : super(debugOwner: debugOwner, kind: kind/*, supportedDevices: supportedDevices */);
+    with
+        NavigatorGesturesPreventingCancelingMixin,
+        NavigatorGesturesOneSequenceMixin {
+  RouteVerticalDragGestureRecognizer(
+      {Object? debugOwner,
+      PointerDeviceKind? kind /*, Set<PointerDeviceKind>? supportedDevices */
+      })
+      : super(
+          debugOwner: debugOwner, /*, supportedDevices: supportedDevices */
+        );
 }

--- a/lib/src/gestures_binding.dart
+++ b/lib/src/gestures_binding.dart
@@ -74,7 +74,7 @@ class NavigatorGesturesFlutterBinding extends WidgetsFlutterBinding with Navigat
   /// [NavigatorGesturesFlutterBinding].
   static WidgetsBinding ensureInitialized() {
     NavigatorGesturesFlutterBinding();
-    return WidgetsBinding.instance!;
+    return WidgetsBinding.instance;
   }
 }
 

--- a/lib/src/gestures_binding.dart
+++ b/lib/src/gestures_binding.dart
@@ -73,7 +73,7 @@ class NavigatorGesturesFlutterBinding extends WidgetsFlutterBinding with Navigat
   /// binding instance to a [TestWidgetsFlutterBinding], not a
   /// [NavigatorGesturesFlutterBinding].
   static WidgetsBinding ensureInitialized() {
-    if (WidgetsBinding.instance == null) NavigatorGesturesFlutterBinding();
+    NavigatorGesturesFlutterBinding();
     return WidgetsBinding.instance!;
   }
 }


### PR DESCRIPTION
Hi,

super nice package! I just found a small issue:

The public getter `  static WidgetsBinding get instance => BindingBase.checkInstance(_instance);` will check if a value exists before returning. Which causes an error. Unfortunately, the derived class `NavigatorGesturesFlutterBinding` can't access the private _instance field in the WidgetsBinding class because it its not part of the library. My idea would be to just remove the check, it should be fine if It is only executed by the parent class. 

Cheers!